### PR TITLE
remove cargo registry in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN echo "[target.aarch64-unknown-linux-gnu]\nobjcopy = { path = \"aarch64-linux
 RUN echo "[target.armv7-unknown-linux-gnueabihf]\nobjcopy = { path = \"arm-linux-gnueabihf-objcopy\" }\nstrip = { path = \"arm-linux-gnueabihf-strip\" }" > ~/.cargo/config
 
 RUN cargo install cargo-deb --version 1.38.0 --locked
+RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -13,6 +13,7 @@ RUN touch ~/.cargo/config
 RUN echo "[target.aarch64-unknown-linux-gnu]\nobjcopy = { path = \"aarch64-linux-gnu-objcopy\" }\nstrip = { path = \"aarch64-linux-gnu-strip\" }\n" > ~/.cargo/config
 
 RUN cargo install cargo-deb --version 1.38.0 --locked
+RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -13,6 +13,7 @@ RUN touch ~/.cargo/config
 RUN echo "[target.armv7-unknown-linux-gnueabihf]\nobjcopy = { path = \"arm-linux-gnueabihf-objcopy\" }\nstrip = { path = \"arm-linux-gnueabihf-strip\" }" > ~/.cargo/config
 
 RUN cargo install cargo-deb --version 1.38.0 --locked
+RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \


### PR DESCRIPTION
Removes the `~/.cargo/registry` folder as its not needed.