### PR TITLE
update cargo-deb to 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN touch ~/.cargo/config
 RUN echo "[target.aarch64-unknown-linux-gnu]\nobjcopy = { path = \"aarch64-linux-gnu-objcopy\" }\nstrip = { path = \"aarch64-linux-gnu-strip\" }\n" > ~/.cargo/config
 RUN echo "[target.armv7-unknown-linux-gnueabihf]\nobjcopy = { path = \"arm-linux-gnueabihf-objcopy\" }\nstrip = { path = \"arm-linux-gnueabihf-strip\" }" > ~/.cargo/config
 
-RUN cargo install cargo-deb --version 1.41.3 --locked
+RUN cargo install cargo-deb --version 2.1.0 --locked
 RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -12,7 +12,7 @@ RUN mkdir -p ~/.cargo/
 RUN touch ~/.cargo/config
 RUN echo "[target.aarch64-unknown-linux-gnu]\nobjcopy = { path = \"aarch64-linux-gnu-objcopy\" }\nstrip = { path = \"aarch64-linux-gnu-strip\" }\n" > ~/.cargo/config
 
-RUN cargo install cargo-deb --version 1.41.3 --locked
+RUN cargo install cargo-deb --version 2.1.0 --locked
 RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -12,7 +12,7 @@ RUN mkdir -p ~/.cargo/
 RUN touch ~/.cargo/config
 RUN echo "[target.armv7-unknown-linux-gnueabihf]\nobjcopy = { path = \"arm-linux-gnueabihf-objcopy\" }\nstrip = { path = \"arm-linux-gnueabihf-strip\" }" > ~/.cargo/config
 
-RUN cargo install cargo-deb --version 1.41.3 --locked
+RUN cargo install cargo-deb --version 2.1.0 --locked
 RUN rm -rf ~/.cargo/registry
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \


### PR DESCRIPTION
Bump versions.

Of note, technical breaking change as per the upstream `cargo-deb` repo:

> Note Since v2.0.0 the deb package version will have a "-1" suffix. You can disable this by adding --deb-revision="" flag or revision = "" in Cargo metadata. The default suffix is for compliance with Debian's packaging standard.